### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
 EspDash KEYWORD1
 
-begin KEYWORD2
-addTab KEYWORD2
-updateTab KEYWORD2
-debug KEYWORD2
-loop KEYWORD2
+begin	KEYWORD2
+addTab	KEYWORD2
+updateTab	KEYWORD2
+debug	KEYWORD2
+loop	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords