### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
-EspDash KEYWORD1
+EspDash	KEYWORD1
 
 begin	KEYWORD2
 addTab	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

(I missed a keyword in https://github.com/ayushsharma82/ESP-DASH/commit/438b24406ea2674ff507b5d0540243585939572e)