### PR TITLE
add no referrer

### DIFF
--- a/vue-frontend/finalize.js
+++ b/vue-frontend/finalize.js
@@ -23,6 +23,7 @@ let html = `
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="referrer" content="no-referrer">
     <title>ESP-DASH</title>
   </head>
   <body>

--- a/vue-frontend/public/index.html
+++ b/vue-frontend/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="referrer" content="no-referrer">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>DASH</title>
   </head>


### PR DESCRIPTION
The browser stops sending the referrer.

Advantage:
* less traffic to esp
* no accidental information leak to other site

Spec:
https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-delivery