### PR TITLE
Minor C code changes

### DIFF
--- a/src/ESPDash.cpp
+++ b/src/ESPDash.cpp
@@ -228,30 +228,6 @@ void ESPDashClass::updateNumberCard(const char* _id, int _value){
 // Temperature Card //
 //////////////////////
 
-// Add Temperature Card with Default Value
-void ESPDashClass::addTemperatureCard(const char* _id, const char* _name, int _type){
-    if(_id != NULL && _type >= 0 && _type <= TEMPERATURE_CARD_TYPES){
-        for(int i=0; i < TEMPERATURE_CARD_LIMIT; i++){
-            if(temperature_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Temperature Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
-
-                temperature_card_id[i] = _id;
-                temperature_card_name[i] = _name;
-                temperature_card_type[i] = _type;
-                temperature_card_value[i] = 0;
-
-                ws.textAll("{\"response\": \"updateLayout\"}");
-                break;
-            }
-        }
-        return;
-    }else{
-        return;
-    }
-}
-
 
 // Add Temperature Card with Custom Value
 void ESPDashClass::addTemperatureCard(const char* _id, const char* _name, int _type, int _value){
@@ -315,29 +291,6 @@ void ESPDashClass::updateTemperatureCard(const char* _id, int _value){
 // Humidity Card //
 ///////////////////
 
-// Add Humidity Card with Default Value
-void ESPDashClass::addHumidityCard(const char* _id, const char* _name){
-    if(_id != NULL){
-        for(int i=0; i < HUMIDITY_CARD_LIMIT; i++){
-            if(humidity_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Humidity Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
-
-                humidity_card_id[i] = _id;
-                humidity_card_name[i] = _name;
-                humidity_card_value[i] = 0;
-
-                ws.textAll("{\"response\": \"updateLayout\"}");
-                break;
-            }
-        }
-        return;
-    }else{
-        return;
-    }
-}
-
 
 // Add Humidity Card with Custom Value
 void ESPDashClass::addHumidityCard(const char* _id, const char* _name, int _value){
@@ -400,32 +353,9 @@ void ESPDashClass::updateHumidityCard(const char* _id, int _value){
 // Status Card //
 /////////////////
 
-// Add Status Card with Default Value
-void ESPDashClass::addStatusCard(const char* _id, const char* _name){
-    if(_id != NULL){
-        for(int i=0; i < STATUS_CARD_LIMIT; i++){
-            if(status_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Status Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
-
-                status_card_id[i] = _id;
-                status_card_name[i] = _name;
-                status_card_value[i] = 0;
-
-                ws.textAll("{\"response\": \"updateLayout\"}");
-                break;
-            }
-        }
-        return;
-    }else{
-        return;
-    }
-}
-
 
 // Add Status Card with Custom Value
-void ESPDashClass::addStatusCard(const char* _id, const char* _name, int _value){
+void ESPDashClass::addStatusCard(const char* _id, const char* _name, int _value = 0){
     if(_id != NULL && _value >= 0 && _value <= STATUS_CARD_TYPES){
         for(int i=0; i < STATUS_CARD_LIMIT; i++){
             if(status_card_id[i] == ""){
@@ -450,65 +380,7 @@ void ESPDashClass::addStatusCard(const char* _id, const char* _name, int _value)
 
 // Add Status Card with Custom Boolean Value
 void ESPDashClass::addStatusCard(const char* _id, const char* _name, bool _value){
-    if(_id != NULL){
-        for(int i=0; i < STATUS_CARD_LIMIT; i++){
-            if(status_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Status Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
-
-                status_card_id[i] = _id;
-                status_card_name[i] = _name;
-                if(_value){
-                    status_card_value[i] = 1;
-                }else{
-                    status_card_value[i] = 0;
-                }
-
-                ws.textAll("{\"response\": \"updateLayout\"}");
-                break;
-            }
-        }
-        return;
-    }else{
-        return;
-    }
-}
-
-
-// Update Status Card with Custom Value
-void ESPDashClass::updateStatusCard(const char* _id, bool _value){
-    for(int i=0; i < STATUS_CARD_LIMIT; i++){
-        if(status_card_id[i] == _id){
-            #if defined(DEBUG_MODE)
-                Serial.println("[DASH] Updated Status Card at Index ["+String(i)+"].");
-            #endif
-
-            if(_value){
-                status_card_value[i] = 1;
-            }else{
-                status_card_value[i] = 0;
-            }
-
-            DynamicJsonDocument doc(250);
-            JsonObject object = doc.to<JsonObject>();
-            object["response"] = "updateStatusCard";
-            object["id"] = status_card_id[i];
-            object["value"] = status_card_value[i];
-            size_t len = measureJson(doc);
-            AsyncWebSocketMessageBuffer * buffer = ws.makeBuffer(len);
-            if (buffer) {
-                serializeJson(doc, (char *)buffer->get(), len + 1);
-                ws.textAll(buffer);
-            }else{
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Websocket Buffer Error");
-                #endif
-            }
-            break;
-        }
-    }
-    return;
+    addStatusCard(_value ? 1 : 0);
 }
 
 
@@ -545,6 +417,12 @@ void ESPDashClass::updateStatusCard(const char* _id, int _value){
     }else{
         return;
     }
+}
+
+
+// Update Status Card with Custom Value
+void ESPDashClass::updateStatusCard(const char* _id, bool _value){
+    updateStatusCard(_value ? 1 : 0);
 }
 
 
@@ -807,28 +685,6 @@ void ESPDashClass::updateLineChart(const char* _id, String _x_axis_value[], int 
 /////////////////
 // Gauge Chart //
 /////////////////
-
-// Add Gauge Card with Default Value
-void ESPDashClass::addGaugeChart(const char* _id, const char* _name){
-    if(_id != NULL){
-        for(int i=0; i < GAUGE_CHART_LIMIT; i++){
-            if(gauge_chart_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Gauge Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
-
-                gauge_chart_id[i] = _id;
-                gauge_chart_name[i] = _name;
-                gauge_chart_value[i] = 0;
-                ws.textAll("{\"response\": \"updateLayout\"}");
-                break;
-            }
-        }
-        return;
-    }else{
-        return;
-    }
-}
 
 // Add Gauge Card with Default Value
 void ESPDashClass::addGaugeChart(const char* _id, const char* _name, int _value){

--- a/src/ESPDash.cpp
+++ b/src/ESPDash.cpp
@@ -1,19 +1,21 @@
 #include "ESPDash.h"
 #include <functional>
 
+#ifdef DEBUG_MODE
+#define debugPrintln(...) Serial.println(__VA_ARGS__)
+#else
+#define debugPrintln(...)
+#endif
+
 AsyncWebSocket ws("/dashws");
 
 
 // Handle Websocket Requests
 void ESPDashClass::onWsEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventType type, void * arg, uint8_t *data, size_t len){
     if(type == WS_EVT_CONNECT){
-        #if defined(DEBUG_MODE)
-            Serial.println("[WEBSOCKET] Client connection received");
-        #endif
+        debugPrintln("[WEBSOCKET] Client connection received");
     } else if(type == WS_EVT_DISCONNECT){
-        #if defined(DEBUG_MODE)
-            Serial.println("[WEBSOCKET] Client disconnected");
-        #endif
+        debugPrintln("[WEBSOCKET] Client disconnected");
     } else if(type == WS_EVT_DATA){
         AwsFrameInfo *info = (AwsFrameInfo*)arg;
         if (info->final && info->index == 0 && info->len == len) {
@@ -28,32 +30,24 @@ void ESPDashClass::onWsEvent(AsyncWebSocket * server, AsyncWebSocketClient * cli
                 }
             }
             
-            #if defined(DEBUG_MODE)
-                Serial.println("[WEBSOCKET] Message Received: "+message);
-            #endif
+            debugPrintln("[WEBSOCKET] Message Received: "+message);
 
             StaticJsonDocument<500> doc;
             DeserializationError err = deserializeJson(doc, message);
             if (err) {
-                #if defined(DEBUG_MODE)
-                    Serial.println(F("deserializeJson() failed: "));
-                    Serial.println(err.c_str());
-                #endif
+                debugPrintln(F("deserializeJson() failed: "));
+                debugPrintln(err.c_str());
             }else{
                 JsonObject object = doc.as<JsonObject>();
                 String command = object["command"];
                 if(command != ""){
                     if(command == "getLayout"){
-                        #if defined(DEBUG_MODE)
-                            Serial.println("[WEBSOCKET] Got getLayout Command from Client "+String(client->id()));
-                        #endif
+                        debugPrintln("[WEBSOCKET] Got getLayout Command from Client "+String(client->id()));
                         String result = "";
                         ESPDash.generateLayoutResponse(result);
                         ws.text(client->id(), result);
                     }else if(command == "getStats"){
-                        #if defined(DEBUG_MODE)
-                            Serial.println("[WEBSOCKET] Got getStats Command from Client "+String(client->id()));
-                        #endif
+                        debugPrintln("[WEBSOCKET] Got getStats Command from Client "+String(client->id()));
                         String result = "";
                         ESPDash.generateStatsResponse(result);
                         ws.text(client->id(), result);
@@ -78,9 +72,7 @@ void ESPDashClass::onWsEvent(AsyncWebSocket * server, AsyncWebSocketClient * cli
                                 }
                             }
 
-                            #if defined(DEBUG_MODE)
-                                Serial.println("buttonClicked Command didn't match any ID in our records! Rouge Request...");
-                            #endif
+                            debugPrintln("buttonClicked Command didn't match any ID in our records! Rouge Request...");
                         }
                     } else if (command == "sliderChanged"){
                         if(ESPDash._sliderChangedFunc != NULL){
@@ -96,15 +88,11 @@ void ESPDashClass::onWsEvent(AsyncWebSocket * server, AsyncWebSocketClient * cli
                                 }
                             }
 
-                            #if defined(DEBUG_MODE)
-                                Serial.println("sliderChanged Command didn't match any ID in our records! Rouge Request...");
-                            #endif
+                            debugPrintln("sliderChanged Command didn't match any ID in our records! Rouge Request...");
                         }                    
                     }
                 }else{
-                    #if defined(DEBUG_MODE)
-                        Serial.println("[WEBSOCKET] Invalid Command");
-                    #endif
+                    debugPrintln("[WEBSOCKET] Invalid Command");
                 }
             }
         }
@@ -124,12 +112,12 @@ void ESPDashClass::init(AsyncWebServer& server){
         request->send(response);        
     });
 
-    #if DEBUG_MODE == 1
-        server.on("/debug", HTTP_GET, [&](AsyncWebServerRequest *request){
-            String json = "";
-            generateLayoutResponse(json);
-            request->send(200, "application/json", json);
-        });
+    #ifdef DEBUG_MODE
+    server.on("/debug", HTTP_GET, [&](AsyncWebServerRequest *request){
+        String json = "";
+        generateLayoutResponse(json);
+        request->send(200, "application/json", json);
+    });
     #endif
 
     ws.onEvent(onWsEvent);
@@ -143,38 +131,13 @@ void ESPDashClass::init(AsyncWebServer& server){
 // Number Card //
 /////////////////
 
-// Add Number Card with Default Value
-void ESPDashClass::addNumberCard(const char* _id, const char* _name){
-    if(_id != NULL){
-        for(int i=0; i < NUMBER_CARD_LIMIT; i++){
-            if(number_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Number Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
-
-                number_card_id[i] = _id;
-                number_card_name[i] = _name;
-                number_card_value[i] = 0;
-
-                ws.textAll("{\"response\": \"updateLayout\"}");
-                break;
-            }
-        }
-        return;
-    }else{
-        return;
-    }
-}
-
 
 // Add Number Card with Custom Value
 void ESPDashClass::addNumberCard(const char* _id, const char* _name, int _value){
     if(_id != NULL){
         for(int i=0; i < NUMBER_CARD_LIMIT; i++){
             if(number_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Number Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Found an empty slot in Number Cards. Inserted New Card at Index ["+String(i)+"].");
 
                 number_card_id[i] = _id;
                 number_card_name[i] = _name;
@@ -195,9 +158,7 @@ void ESPDashClass::addNumberCard(const char* _id, const char* _name, int _value)
 void ESPDashClass::updateNumberCard(const char* _id, int _value){
     for(int i=0; i < NUMBER_CARD_LIMIT; i++){
         if(number_card_id[i] == _id){
-            #if defined(DEBUG_MODE)
-                Serial.println("[DASH] Updated Number Card at Index ["+String(i)+"].");
-            #endif
+            debugPrintln("[DASH] Updated Number Card at Index ["+String(i)+"].");
 
             number_card_value[i] = _value;
 
@@ -212,9 +173,7 @@ void ESPDashClass::updateNumberCard(const char* _id, int _value){
                 serializeJson(doc, (char *)buffer->get(), len + 1);
                 ws.textAll(buffer);
             }else{
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Websocket Buffer Error");
-                #endif
+                debugPrintln("[DASH] Websocket Buffer Error");
             }
             break;
         }
@@ -234,9 +193,7 @@ void ESPDashClass::addTemperatureCard(const char* _id, const char* _name, int _t
     if(_id != NULL && _type >= 0 && _type <= TEMPERATURE_CARD_TYPES){
         for(int i=0; i < TEMPERATURE_CARD_LIMIT; i++){
             if(temperature_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Temperature Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Found an empty slot in Temperature Cards. Inserted New Card at Index ["+String(i)+"].");
 
                 temperature_card_id[i] = _id;
                 temperature_card_name[i] = _name;
@@ -258,9 +215,7 @@ void ESPDashClass::addTemperatureCard(const char* _id, const char* _name, int _t
 void ESPDashClass::updateTemperatureCard(const char* _id, int _value){
     for(int i=0; i < TEMPERATURE_CARD_LIMIT; i++){
         if(temperature_card_id[i] == _id){
-            #if defined(DEBUG_MODE)
-                Serial.println("[DASH] Updated Temperature Card at Index ["+String(i)+"].");
-            #endif
+            debugPrintln("[DASH] Updated Temperature Card at Index ["+String(i)+"].");
 
             temperature_card_value[i] = _value;
 
@@ -275,9 +230,7 @@ void ESPDashClass::updateTemperatureCard(const char* _id, int _value){
                 serializeJson(doc, (char *)buffer->get(), len + 1);
                 ws.textAll(buffer);
             }else{
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Websocket Buffer Error");
-                #endif
+                debugPrintln("[DASH] Websocket Buffer Error");
             }
             break;
         }
@@ -297,9 +250,7 @@ void ESPDashClass::addHumidityCard(const char* _id, const char* _name, int _valu
     if(_id != NULL){
         for(int i=0; i < HUMIDITY_CARD_LIMIT; i++){
             if(humidity_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Humidity Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Found an empty slot in Humidity Cards. Inserted New Card at Index ["+String(i)+"].");
 
                 humidity_card_id[i] = _id;
                 humidity_card_name[i] = _name;
@@ -320,9 +271,7 @@ void ESPDashClass::addHumidityCard(const char* _id, const char* _name, int _valu
 void ESPDashClass::updateHumidityCard(const char* _id, int _value){
     for(int i=0; i < HUMIDITY_CARD_LIMIT; i++){
         if(humidity_card_id[i] == _id){
-            #if defined(DEBUG_MODE)
-                Serial.println("[DASH] Updated Humidity Card at Index ["+String(i)+"].");
-            #endif
+            debugPrintln("[DASH] Updated Humidity Card at Index ["+String(i)+"].");
 
             humidity_card_value[i] = _value;
 
@@ -337,9 +286,7 @@ void ESPDashClass::updateHumidityCard(const char* _id, int _value){
                 serializeJson(doc, (char *)buffer->get(), len + 1);
                 ws.textAll(buffer);
             }else{
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Websocket Buffer Error");
-                #endif
+                debugPrintln("[DASH] Websocket Buffer Error");
             }
             break;
         }
@@ -355,13 +302,11 @@ void ESPDashClass::updateHumidityCard(const char* _id, int _value){
 
 
 // Add Status Card with Custom Value
-void ESPDashClass::addStatusCard(const char* _id, const char* _name, int _value = 0){
+void ESPDashClass::addStatusCard(const char* _id, const char* _name, int _value){
     if(_id != NULL && _value >= 0 && _value <= STATUS_CARD_TYPES){
         for(int i=0; i < STATUS_CARD_LIMIT; i++){
             if(status_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Status Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Found an empty slot in Status Cards. Inserted New Card at Index ["+String(i)+"].");
 
                 status_card_id[i] = _id;
                 status_card_name[i] = _name;
@@ -380,7 +325,7 @@ void ESPDashClass::addStatusCard(const char* _id, const char* _name, int _value 
 
 // Add Status Card with Custom Boolean Value
 void ESPDashClass::addStatusCard(const char* _id, const char* _name, bool _value){
-    addStatusCard(_value ? 1 : 0);
+    addStatusCard(_id, _name, _value ? 1 : 0);
 }
 
 
@@ -389,9 +334,7 @@ void ESPDashClass::updateStatusCard(const char* _id, int _value){
     if(_value >= 0 && _value <= STATUS_CARD_TYPES){
         for(int i=0; i < STATUS_CARD_LIMIT; i++){
             if(status_card_id[i] == _id){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Updated Status Card at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Updated Status Card at Index ["+String(i)+"].");
 
                 status_card_value[i] = _value;
 
@@ -406,9 +349,7 @@ void ESPDashClass::updateStatusCard(const char* _id, int _value){
                     serializeJson(doc, (char *)buffer->get(), len + 1);
                     ws.textAll(buffer);
                 }else{
-                    #if defined(DEBUG_MODE)
-                        Serial.println("[DASH] Websocket Buffer Error");
-                    #endif
+                    debugPrintln("[DASH] Websocket Buffer Error");
                 }
                 break;
             }
@@ -422,7 +363,7 @@ void ESPDashClass::updateStatusCard(const char* _id, int _value){
 
 // Update Status Card with Custom Value
 void ESPDashClass::updateStatusCard(const char* _id, bool _value){
-    updateStatusCard(_value ? 1 : 0);
+    updateStatusCard(_id, _value ? 1 : 0);
 }
 
 
@@ -436,9 +377,7 @@ void ESPDashClass::addButtonCard(const char* _id, const char* _name){
     if(_id != NULL){
         for(int i=0; i < BUTTON_CARD_LIMIT; i++){
             if(button_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Button Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Found an empty slot in Button Cards. Inserted New Card at Index ["+String(i)+"].");
 
                 button_card_id[i] = _id;
                 button_card_name[i] = _name;
@@ -461,9 +400,7 @@ void ESPDashClass::addSliderCard(const char* _id, const char* _name, int _type){
     if(_id != NULL && _type >= 0 && _type <= SLIDER_CARD_TYPES){
         for(int i=0; i < SLIDER_CARD_LIMIT; i++){
             if(slider_card_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Slider Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Found an empty slot in Slider Cards. Inserted New Card at Index ["+String(i)+"].");
 
                 slider_card_id[i]    = _id;
                 slider_card_name[i]  = _name;
@@ -484,9 +421,7 @@ void ESPDashClass::addSliderCard(const char* _id, const char* _name, int _type){
 void ESPDashClass::updateSliderCard(const char* _id, int _value){
     for(int i=0; i < SLIDER_CARD_LIMIT; i++){
         if(slider_card_id[i] == _id){
-            #if defined(DEBUG_MODE)
-                Serial.println("[DASH] Updated Slider Card at Index ["+String(i)+"].");
-            #endif
+            debugPrintln("[DASH] Updated Slider Card at Index ["+String(i)+"].");
 
             slider_card_value[i] = _value;
 
@@ -501,9 +436,7 @@ void ESPDashClass::updateSliderCard(const char* _id, int _value){
                 serializeJson(doc, (char *)buffer->get(), len + 1);
                 ws.textAll(buffer);
             }else{
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Websocket Buffer Error (updateSliderCard())");
-                #endif
+                debugPrintln("[DASH] Websocket Buffer Error (updateSliderCard())");
             }
             break;
         }
@@ -522,9 +455,7 @@ void ESPDashClass::addLineChart(const char* _id, const char* _name, int _x_axis_
     if(_id != NULL){
         for(int i=0; i < LINE_CHART_LIMIT; i++){
             if(line_chart_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Line Charts. Inserted New Chart at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Found an empty slot in Line Charts. Inserted New Chart at Index ["+String(i)+"].");
 
                 line_chart_id[i] = _id;
                 line_chart_name[i] = _name;
@@ -556,9 +487,7 @@ void ESPDashClass::addLineChart(const char* _id, const char* _name, String _x_ax
     if(_id != NULL){
         for(int i=0; i < LINE_CHART_LIMIT; i++){
             if(line_chart_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Line Charts. Inserted New Chart at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Found an empty slot in Line Charts. Inserted New Chart at Index ["+String(i)+"].");
 
                 line_chart_id[i] = _id;
                 line_chart_name[i] = _name;
@@ -590,9 +519,7 @@ void ESPDashClass::addLineChart(const char* _id, const char* _name, String _x_ax
 void ESPDashClass::updateLineChart(const char* _id, int _x_axis_value[], int _x_axis_size, int _y_axis_value[], int _y_axis_size){
     for(int i=0; i < LINE_CHART_LIMIT; i++){
         if(line_chart_id[i] == _id){
-            #if defined(DEBUG_MODE)
-                Serial.println("[DASH] Updated Line Chart at Index ["+String(i)+"].");
-            #endif
+            debugPrintln("[DASH] Updated Line Chart at Index ["+String(i)+"].");
 
             if(line_chart_x_axis_type[i] == false){
                 
@@ -622,9 +549,7 @@ void ESPDashClass::updateLineChart(const char* _id, int _x_axis_value[], int _x_
                     serializeJson(doc, (char *)buffer->get(), len + 1);
                     ws.textAll(buffer);
                 }else{
-                    #if defined(DEBUG_MODE)
-                        Serial.println("[DASH] Websocket Buffer Error");
-                    #endif
+                    debugPrintln("[DASH] Websocket Buffer Error");
                 }
             }
             break;
@@ -638,9 +563,7 @@ void ESPDashClass::updateLineChart(const char* _id, int _x_axis_value[], int _x_
 void ESPDashClass::updateLineChart(const char* _id, String _x_axis_value[], int _x_axis_size, int _y_axis_value[], int _y_axis_size){
     for(int i=0; i < LINE_CHART_LIMIT; i++){
         if(line_chart_id[i] == _id){
-            #if defined(DEBUG_MODE)
-                Serial.println("[DASH] Updated Line Chart at Index ["+String(i)+"].");
-            #endif
+            debugPrintln("[DASH] Updated Line Chart at Index ["+String(i)+"].");
 
             if(line_chart_x_axis_type[i] == true){
                 
@@ -670,9 +593,7 @@ void ESPDashClass::updateLineChart(const char* _id, String _x_axis_value[], int 
                     serializeJson(doc, (char *)buffer->get(), len + 1);
                     ws.textAll(buffer);
                 }else{
-                    #if defined(DEBUG_MODE)
-                        Serial.println("[DASH] Websocket Buffer Error");
-                    #endif
+                    debugPrintln("[DASH] Websocket Buffer Error");
                 }
             }
             break;
@@ -691,9 +612,7 @@ void ESPDashClass::addGaugeChart(const char* _id, const char* _name, int _value)
     if(_id != NULL){
         for(int i=0; i < GAUGE_CHART_LIMIT; i++){
             if(gauge_chart_id[i] == ""){
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Found an empty slot in Gauge Cards. Inserted New Card at Index ["+String(i)+"].");
-                #endif
+                debugPrintln("[DASH] Found an empty slot in Gauge Cards. Inserted New Card at Index ["+String(i)+"].");
 
                 gauge_chart_id[i] = _id;
                 gauge_chart_name[i] = _name;
@@ -713,9 +632,7 @@ void ESPDashClass::addGaugeChart(const char* _id, const char* _name, int _value)
 void ESPDashClass::updateGaugeChart(const char* _id, int _value){
     for(int i=0; i < GAUGE_CHART_LIMIT; i++){
         if(gauge_chart_id[i] == _id){
-            #if defined(DEBUG_MODE)
-                Serial.println("[DASH] Updated Gauge Chart at Index ["+String(i)+"].");
-            #endif
+            debugPrintln("[DASH] Updated Gauge Chart at Index ["+String(i)+"].");
 
             gauge_chart_value[i] = _value;
 
@@ -730,9 +647,7 @@ void ESPDashClass::updateGaugeChart(const char* _id, int _value){
                 serializeJson(doc, (char *)buffer->get(), len + 1);
                 ws.textAll(buffer);
             }else{
-                #if defined(DEBUG_MODE)
-                    Serial.println("[DASH] Websocket Buffer Error");
-                #endif
+                debugPrintln("[DASH] Websocket Buffer Error");
             }
             break;
         }
@@ -747,9 +662,7 @@ void ESPDashClass::updateGaugeChart(const char* _id, int _value){
 ///////////////////////
 
 void ESPDashClass::generateLayoutResponse(String& result){
-    #if defined(DEBUG_MODE)
-        Serial.println("Free HEAP = before = JSON Serialization: "+String(ESP.getFreeHeap()));
-    #endif
+    debugPrintln("Free HEAP = before = JSON Serialization: "+String(ESP.getFreeHeap()));
 
     size_t CAPACITY = getTotalResponseCapacity();
 
@@ -896,9 +809,7 @@ void ESPDashClass::generateLayoutResponse(String& result){
 
     serializeJson(doc, result);
 
-    #if defined(DEBUG_MODE)
-        Serial.println("Free HEAP = after = JSON Serialization: "+String(ESP.getFreeHeap()));
-    #endif
+    debugPrintln("Free HEAP = after = JSON Serialization: "+String(ESP.getFreeHeap()));
 
     return;
 }
@@ -906,9 +817,7 @@ void ESPDashClass::generateLayoutResponse(String& result){
 
 
 void ESPDashClass::generateStatsResponse(String& result){
-    #if defined(DEBUG_MODE)
-        Serial.println("Free HEAP = before = JSON Serialization: "+String(ESP.getFreeHeap()));
-    #endif
+    debugPrintln("Free HEAP = before = JSON Serialization: "+String(ESP.getFreeHeap()));
 
     DynamicJsonDocument doc(500);
     JsonObject stats = doc.to<JsonObject>();
@@ -935,18 +844,14 @@ void ESPDashClass::generateStatsResponse(String& result){
 
     serializeJson(doc, result);
 
-    #if defined(DEBUG_MODE)
-        Serial.println("Free HEAP = after = JSON Serialization: "+String(ESP.getFreeHeap()));
-    #endif
+    debugPrintln("Free HEAP = after = JSON Serialization: "+String(ESP.getFreeHeap()));
 
     return;
 }
 
 
 void ESPDashClass::generateRebootResponse(String& result){
-    #if defined(DEBUG_MODE)
-        Serial.println("Free HEAP = before = JSON Serialization: "+String(ESP.getFreeHeap()));
-    #endif
+    debugPrintln("Free HEAP = before = JSON Serialization: "+String(ESP.getFreeHeap()));
 
     DynamicJsonDocument doc(200);
     JsonObject obj = doc.to<JsonObject>();
@@ -959,9 +864,7 @@ void ESPDashClass::generateRebootResponse(String& result){
 
     serializeJson(doc, result);
 
-    #if defined(DEBUG_MODE)
-        Serial.println("Free HEAP = after = JSON Serialization: "+String(ESP.getFreeHeap()));
-    #endif
+    debugPrintln("Free HEAP = after = JSON Serialization: "+String(ESP.getFreeHeap()));
 
     return;
 }

--- a/src/ESPDash.h
+++ b/src/ESPDash.h
@@ -48,10 +48,6 @@ typedef std::function<void(const char* sliderId, int sliderValue)> DashSliderHan
 #define DEBUG_MODE 1 // change to 1 for DEBUG Messages
 
 // Debug mode
-#ifndef DEBUG_MODE
-#define DEBUG_MODE 0
-#endif
-
 #define TEMPERATURE_CARD_TYPES 6
 #define STATUS_CARD_TYPES 4
 #define SLIDER_CARD_TYPES 4

--- a/src/ESPDash.h
+++ b/src/ESPDash.h
@@ -84,30 +84,26 @@ class ESPDashClass{
         void init(AsyncWebServer& server);
         void disableStats();    // To Disable Stats and disable reboot
 
-        void addNumberCard(const char* _id, const char* _name); // Add Number card with default value
-        void addNumberCard(const char* _id, const char* _name, int _value); // Add Number card with custom value
+        void addNumberCard(const char* _id, const char* _name, int _value = 0); // Add Number card with custom value
         void updateNumberCard(const char* _id, int _value); // Update Number Card with custom value
 
-        void addTemperatureCard(const char* _id, const char* _name, int _type); // Add Temperature Card with custom type and default value
-        void addTemperatureCard(const char* _id, const char* _name, int _type, int _value); // Add Temperature Card with custom value
+        void addTemperatureCard(const char* _id, const char* _name, int _type, int _value = 0); // Add Temperature Card with custom value
         void updateTemperatureCard(const char* _id, int _value); // Update Temperature Card with custom value
 
-        void addHumidityCard(const char* _id, const char* _name);   // Add default Humidity card
-        void addHumidityCard(const char* _id, const char* _name, int _value);  // Add Humidity Card with custom value
+        void addHumidityCard(const char* _id, const char* _name, int _value = 0);  // Add Humidity Card with custom value
         void updateHumidityCard(const char* _id, int _value); // Update Humidity Card with custom value
 
-        void addStatusCard(const char* _id, const char* _name); // Add Default Status Card
-        void addStatusCard(const char* _id, const char* _name, int _type); // Add Status Card with more status types
+        void addStatusCard(const char* _id, const char* _name, int _type = 0); // Add Status Card with more status types
         void addStatusCard(const char* _id, const char* _name, bool _type); // Add Status Card with true / false
         void updateStatusCard(const char* _id, int _type);
         void updateStatusCard(const char* _id, bool _type);
 
         void addButtonCard(const char* _id, const char* _name); // Add Button
-        
+
         // Add Slider Card 
         void addSliderCard(const char* _id, const char* _name, int _type); 
         void updateSliderCard(const char* _id, int _value); 
-        
+
         //Initiate a Line Chart with Integer x axis and custom y axis
         void addLineChart(const char* _id, const char* _name, int _x_axis_value[], int _x_axis_size, const char* _y_axis_name, int _y_axis_value[], int _y_axis_size);
         // Initiate a Line Chart with String x axis and custom y axis
@@ -115,20 +111,19 @@ class ESPDashClass{
         void updateLineChart(const char* _id, int _x_axis_value[], int _x_axis_size, int _y_axis_value[], int _y_axis_size); // Update a Line Chart with custom Int x axis and y axis
         void updateLineChart(const char* _id, String _x_axis_value[], int _x_axis_size, int _y_axis_value[], int _y_axis_size); // Update a Line Chart with custom String x axis and y axis
 
-        void addGaugeChart(const char *_id, const char *_name); // Add Gauge card with default value
-        void addGaugeChart(const char *_id, const char *_name, int _value); // Add Gauge card with default value
-        void updateGaugeChart(const char* _id, int _value); // Update Gauge card with default value
+        void addGaugeChart(const char *_id, const char *_name, int _value = 0); // Add Gauge card
+        void updateGaugeChart(const char* _id, int _value); // Update Gauge card
 
 
         void attachButtonClick(DashButtonHandler handler){
             _buttonClickFunc = handler;
         }
-        
+
         void attachSliderChanged(DashSliderHandler handler){
             _sliderChangedFunc = handler;
         }
 
-        
+
     private:
         bool stats_enabled = true;
         DashButtonHandler _buttonClickFunc;


### PR DESCRIPTION
This pull request includes two commits -- the first one removes code duplication by using the C++ default arguments feature.  This allows to only keep one version of each of the twin functions like `addNumberCard`, `addTemperatureCard` etc. while keeping the API unchanged.

The second commit fixes a minor bug related to the `DEBUG_MODE` macro which caused the messages to always get printed.  Even if `DEBUG_MODE` was defined as 0, the messages got printed, because the preprocessor `#if` conditions only checked if `DEBUG_MODE` was defined, no matter what value it had.  

Additionally, to improve code readablilty, the second commit introduces a special macro, which allows to skip the preprocessor check for `DEBUG_MODE` at the top of the file instead of having multiple `#if` blocks surrounding each print call.