### PR TITLE
[Security] Forbid indexation by robots

### DIFF
--- a/vue-frontend/finalize.js
+++ b/vue-frontend/finalize.js
@@ -25,6 +25,7 @@ let html = `
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="referrer" content="no-referrer">
+    <meta name="robots" content="noindex">
     <title>ESP-DASH</title>
   </head>
   <body>


### PR DESCRIPTION
Dashboard can not be found by respectful search engines, if ESP is accidentally public.