### PR TITLE
Fixed: Generic Card - ( String Datatype )

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ version: ~> 1.0
 
 language: python
 python:
-    - "2.7"
+    - "3.9"
 sudo: false
 cache:
     directories:

--- a/src/Card.cpp
+++ b/src/Card.cpp
@@ -65,8 +65,6 @@ void Card::update(float value, const char* symbol){
   if(_value_f != value)
     _changed = true;
   _value_f = value;
-
-  if(_value_type )
 }
 
 void Card::update(float value){

--- a/src/Card.cpp
+++ b/src/Card.cpp
@@ -61,35 +61,23 @@ void Card::update(float value){
 
 void Card::update(const String &value, const char* symbol){
   if(_value_type == Card::STRING){
-    if(strcmp(_value_s, value.c_str()) != 0)
+    if(strcmp(_value_s.c_str(), value.c_str()) != 0)
       _changed = true;
-
-    if(_value_s != NULL)
-      delete[] _value_s;
   }
   
   _value_type = Card::STRING;
   _symbol = symbol;
-
-  int size = value.length();
-  _value_s = new char[size+1];
-  strncpy(_value_s, value.c_str(), size);
+  _value_s = value;
 }
 
 void Card::update(const String &value){
     if(_value_type == Card::STRING){
-    if(strcmp(_value_s, value.c_str()) != 0)
+    if(strcmp(_value_s.c_str(), value.c_str()) != 0)
       _changed = true;
-
-    if(_value_s != NULL)
-      delete[] _value_s;
   }
   
   _value_type = Card::STRING;
-
-  int size = value.length();
-  _value_s = new char[size+1];
-  strncpy(_value_s, value.c_str(), size);
+  _value_s = value;
 }
 
 void Card::update(bool value, const char* symbol){

--- a/src/Card.cpp
+++ b/src/Card.cpp
@@ -30,6 +30,11 @@ void Card::attachCallback(std::function<void(int value)> cb){
   Value update methods
 */
 void Card::update(int value, const char* symbol){
+  /* Clear String if it was used before */
+  if(_value_type == Card::STRING){
+    _value_s = "";
+  }
+  /* Store new value */
   _value_type = Card::INTEGER;
   _symbol = symbol;
   if(_value_i != value)
@@ -38,6 +43,11 @@ void Card::update(int value, const char* symbol){
 }
 
 void Card::update(int value){
+  /* Clear String if it was used before */
+  if(_value_type == Card::STRING){
+    _value_s = "";
+  }
+  /* Store new value */
   _value_type = Card::INTEGER;
   if(_value_i != value)
     _changed = true;
@@ -45,14 +55,26 @@ void Card::update(int value){
 }
 
 void Card::update(float value, const char* symbol){
+  /* Clear String if it was used before */
+  if(_value_type == Card::STRING){
+    _value_s = "";
+  }
+  /* Store new value */
   _value_type = Card::FLOAT;
   _symbol = symbol;
   if(_value_f != value)
     _changed = true;
   _value_f = value;
+
+  if(_value_type )
 }
 
 void Card::update(float value){
+  /* Clear String if it was used before */
+  if(_value_type == Card::STRING){
+    _value_s = "";
+  }
+  /* Store new value */
   _value_type = Card::FLOAT;
   if(_value_f != value)
     _changed = true;
@@ -81,6 +103,11 @@ void Card::update(const String &value){
 }
 
 void Card::update(bool value, const char* symbol){
+  /* Clear String if it was used before */
+  if(_value_type == Card::STRING){
+    _value_s = "";
+  }
+  /* Store new value */
   _value_type = Card::INTEGER;
   _symbol = symbol;
   if(_value_i != value)
@@ -89,6 +116,11 @@ void Card::update(bool value, const char* symbol){
 }
 
 void Card::update(bool value){
+  /* Clear String if it was used before */
+  if(_value_type == Card::STRING){
+    _value_s = "";
+  }
+  /* Store new value */
   _value_type = Card::INTEGER;
   if(_value_i != value)
     _changed = true;

--- a/src/Card.h
+++ b/src/Card.h
@@ -37,11 +37,11 @@ class Card {
     int   _type;
     bool  _changed;
     enum { INTEGER, FLOAT, STRING } _value_type;
-    union alignas(8) {
-        char *_value_s;
+    union alignas(4) {
         float _value_f;
         int _value_i;
     };
+    String _value_s;
     int _value_min;
     int _value_max;
     String _symbol;


### PR DESCRIPTION
Now Card class uses `String` for storing const char arrays. This fixes the heap corruption issue arising in the previous version.