### PR TITLE
Fix compile on ESP-IDF 4.4.3

### DIFF
--- a/src/Statistic.cpp
+++ b/src/Statistic.cpp
@@ -8,15 +8,21 @@ Statistic::Statistic(ESPDash *dashboard, const char *key, const char *value) {
         _id = esp_random();
     #endif
     // Safe copy
-    strncpy(_key, key, sizeof(_key));
-    strncpy(_value, value, sizeof(_value));
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wstringop-truncation"
+        strncpy(_key, key, sizeof(_key));
+        strncpy(_value, value, sizeof(_value));
+    #pragma GCC diagnostic pop
     _dashboard->add(this);
 }
 
 void Statistic::set(const char *key, const char *value) {
     // Safe copy
-    strncpy(_key, key, sizeof(_key));
-    strncpy(_value, value, sizeof(_value));
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wstringop-truncation"
+        strncpy(_key, key, sizeof(_key));
+        strncpy(_value, value, sizeof(_value));
+    #pragma GCC diagnostic pop
     _changed = true;
 }
 


### PR DESCRIPTION
I was seeing [this](https://stackoverflow.com/questions/50198319/gcc-8-wstringop-truncation-what-is-the-good-practice) issue in ESP-IDF, this fixed it 