### PR TITLE
Use better maintained ESPAsyncWebServer-esphome fork

### DIFF
--- a/library.json
+++ b/library.json
@@ -21,8 +21,8 @@
   "dependencies":
   [
     {
-      "name": "ESP Async WebServer",
-      "version": "1.2.3"
+      "name": "ESPAsyncWebServer-esphome",
+      "version": "3.0.0"
     },
     {
       "name": "ArduinoJson",


### PR DESCRIPTION
Since the original ESP Async Web Server library seems to be abandoned and throws some compiler errors, I would suggest to switch to the esphome maintained fork.