### PR TITLE
1. Only send updated stats

### DIFF
--- a/src/Statistic.cpp
+++ b/src/Statistic.cpp
@@ -15,15 +15,19 @@ Statistic::Statistic(ESPDash *dashboard, const char *key, const char *value) {
 
 void Statistic::set(const char *key, const char *value) {
     // Safe copy
-    strncpy(_key, key, sizeof(_key));
-    strncpy(_value, value, sizeof(_value));
-    _changed = true;
+    _changed = strcmp(_value, value) != 0 || strcmp(_key, key) != 0;
+    if(_changed) {
+        strncpy(_key, key, sizeof(_key));
+        strncpy(_value, value, sizeof(_value));
+    }
 }
 
 void Statistic::set(const char *value) {
     // Safe copy
-    strncpy(_value, value, sizeof(_value));
-    _changed = true;
+    _changed = strcmp(_value, value) != 0;
+    if(_changed)
+        strncpy(_value, value, sizeof(_value));
+    
 }
 
 Statistic::~Statistic() {


### PR DESCRIPTION
Transferring the same logic as in the cards to avoid sending stats not updated.
