### PR TITLE
2. Add ability to force refresh a particular card

### DIFF
--- a/src/ESPDash.cpp
+++ b/src/ESPDash.cpp
@@ -163,7 +163,7 @@ void ESPDash::remove(Statistic *statistic) {
 }
 
 // generates the layout JSON string to the frontend
-size_t ESPDash::generateLayoutJSON(AsyncWebSocketClient *client, bool changes_only) {
+size_t ESPDash::generateLayoutJSON(AsyncWebSocketClient *client, bool changes_only, Card *onlyCard) {
   String buf = "";
   buf.reserve(DASH_LAYOUT_JSON_SIZE);
 
@@ -183,7 +183,7 @@ size_t ESPDash::generateLayoutJSON(AsyncWebSocketClient *client, bool changes_on
     if (changes_only) {
       if (c->_changed) {
         c->_changed = false;
-      } else {
+      } else if (onlyCard == nullptr || onlyCard->_id != c->_id) {
         continue;
       }
     }
@@ -459,6 +459,10 @@ void ESPDash::refreshLayout() {
 
 void ESPDash::refreshStatistics() {
   generateLayoutJSON(nullptr, true);
+}
+
+void ESPDash::refreshCard(Card *card) {
+  generateLayoutJSON(nullptr, true, card);
 }
 
 

--- a/src/ESPDash.h
+++ b/src/ESPDash.h
@@ -80,7 +80,7 @@ class ESPDash{
     char password[64];
 
     // Generate layout json
-    size_t generateLayoutJSON(AsyncWebSocketClient *client, bool changes_only = false);
+    size_t generateLayoutJSON(AsyncWebSocketClient *client, bool changes_only = false, Card *onlyCard = nullptr);
 
     // Generate Component JSON
     void generateComponentJSON(JsonObject& obj, Card* card, bool change_only = false);
@@ -117,6 +117,7 @@ class ESPDash{
     void sendUpdates(bool force = false);
 
     void refreshStatistics();
+    void refreshCard(Card *card);
 
     ~ESPDash();
 };


### PR DESCRIPTION
This PR adds the ability to only refresh a specific card.

This could be used in the case where the user click on  a switch, but some application logic is preventing the switch to turn on. In this case, since there is no update of the component, the yellow waiting icon stays and blinks, as reported in issue #179.

So it is possible to force update only this specific component in the callback to avoid that.

A typical use case is:

```cpp
buttonCard.attachCallback([&](int value) {
    if(application logic autorise the switch) {
      // do something
      dashboard.sendUpdates();
    }  else {
      // switch is prevented, but the component still needs to be refreshed to clear the waiting yellow icon
      dashboard.refreshCard(&buttonCard); 
    }
});
```