### PR TITLE
3. Correctly generate component ids

### DIFF
--- a/src/Card.cpp
+++ b/src/Card.cpp
@@ -5,11 +5,7 @@
 */
 Card::Card(ESPDash *dashboard, const int type, const char* name, const char* symbol, const int min, const int max){
   _dashboard = dashboard;
-  #if defined(ESP8266)
-    _id = RANDOM_REG32;
-  #elif defined(ESP32)
-    _id = esp_random();
-  #endif
+  _id = dashboard->nextId();
   _type = type;
   _name = name;
   _symbol = symbol;

--- a/src/Chart.cpp
+++ b/src/Chart.cpp
@@ -5,11 +5,7 @@
 */
 Chart::Chart(ESPDash *dashboard, const int type, const char* name){
   _dashboard = dashboard;
-  #if defined(ESP8266)
-    _id = RANDOM_REG32;
-  #elif defined(ESP32)
-    _id = esp_random();
-  #endif
+  _id = dashboard->nextId();
   _type = type;
   _name = name;
   _dashboard->add(this);

--- a/src/ESPDash.cpp
+++ b/src/ESPDash.cpp
@@ -461,6 +461,9 @@ void ESPDash::refreshStatistics() {
   generateLayoutJSON(nullptr, true);
 }
 
+uint32_t ESPDash::nextId() {
+  return _idCounter++;
+}
 
 /*
   Destructor

--- a/src/ESPDash.h
+++ b/src/ESPDash.h
@@ -78,6 +78,7 @@ class ESPDash{
     bool basic_auth = false;
     char username[64];
     char password[64];
+    uint32_t _idCounter = 0;
 
     // Generate layout json
     size_t generateLayoutJSON(AsyncWebSocketClient *client, bool changes_only = false);
@@ -117,6 +118,8 @@ class ESPDash{
     void sendUpdates(bool force = false);
 
     void refreshStatistics();
+
+    uint32_t nextId();
 
     ~ESPDash();
 };

--- a/src/Statistic.cpp
+++ b/src/Statistic.cpp
@@ -2,11 +2,7 @@
 
 Statistic::Statistic(ESPDash *dashboard, const char *key, const char *value) {
     _dashboard = dashboard;
-    #if defined(ESP8266)
-        _id = RANDOM_REG32;
-    #elif defined(ESP32)
-        _id = esp_random();
-    #endif
+    _id = dashboard->nextId();
     // Safe copy
     strncpy(_key, key, sizeof(_key));
     strncpy(_value, value, sizeof(_value));


### PR DESCRIPTION
Generating ids based on random generator can lead to collision when we have a lot of items.

Plus, after a firmware flash, ids will change, even if the layout did not change, so any websocket call to update could send a payload to the browser before it is refreshed with the right layout.

Also, this will generate ids way shorter than random ones, so it will decrease the payload size significantly.

Benefit of this change is that if the layout does not change (I mean, the order of components in the c code), the ids will be generated the same way.