### PR TITLE
4. Improve memory usage related to websocket

### DIFF
--- a/src/ESPDash.cpp
+++ b/src/ESPDash.cpp
@@ -164,8 +164,21 @@ void ESPDash::remove(Statistic *statistic) {
 
 // generates the layout JSON string to the frontend
 size_t ESPDash::generateLayoutJSON(AsyncWebSocketClient *client, bool changes_only) {
+  // https://github.com/me-no-dev/ESPAsyncWebServer#limiting-the-number-of-web-socket-clients
+  // Browsers sometimes do not correctly close the websocket connection, even when the close() function is called in javascript.
+  // This will eventually exhaust the web server's resources and will cause the server to crash.
+  // Use DEFAULT_MAX_WS_CLIENTS or DASH_MAX_WS_CLIENTS (specific to ESP-DASH) to set the maximum number of clients
+  _ws->cleanupClients();
+
+  const size_t clients = _ws->count();
+  
+  if (clients == 0) {
+    // do not consume cpu and memory if no client is connected
+    return 0;
+  }
+
   String buf = "";
-  buf.reserve(DASH_LAYOUT_JSON_SIZE);
+  buf.reserve(changes_only ? DASH_PARTIAL_UPDATE_JSON_SIZE : DASH_LAYOUT_JSON_SIZE);
 
   if (changes_only) {
     buf += "{\"command\":\"update:components\",";
@@ -315,6 +328,9 @@ size_t ESPDash::generateLayoutJSON(AsyncWebSocketClient *client, bool changes_on
   // Store the length of the JSON string
   size_t total = buf.length();
   // Send resp
+  #ifdef DASH_DEBUG
+  Serial.printf("client=%d, count=%d, changes_only=%d, total=%d\n%s\n", (client == nullptr ? -1 : client->id()), clients, changes_only, total, buf.c_str());
+  #endif
   if (client != nullptr) {
     _ws->text(client->id(), buf.c_str(), total);
   } else {
@@ -461,6 +477,9 @@ void ESPDash::refreshStatistics() {
   generateLayoutJSON(nullptr, true);
 }
 
+bool ESPDash::hasClient() {
+  return _ws->count() > 0;
+}
 
 /*
   Destructor

--- a/src/ESPDash.h
+++ b/src/ESPDash.h
@@ -44,8 +44,8 @@ Github URL: https://github.com/ayushsharma82/ESP-DASH
   #define DASH_LAYOUT_JSON_SIZE 1024 * 5
 #endif
 
-#ifndef DASH_STATISTICS_JSON_SIZE
-  #define DASH_STATISTICS_JSON_SIZE 1024 * 1
+#ifndef DASH_PARTIAL_UPDATE_JSON_SIZE
+  #define DASH_PARTIAL_UPDATE_JSON_SIZE DASH_LAYOUT_JSON_SIZE
 #endif
 
 #ifndef DASH_CARD_JSON_SIZE
@@ -58,6 +58,10 @@ Github URL: https://github.com/ayushsharma82/ESP-DASH
 
 #ifndef DASH_USE_LEGACY_CHART_STORAGE
   #define DASH_USE_LEGACY_CHART_STORAGE 0
+#endif
+
+#ifndef DASH_MAX_WS_CLIENTS
+  #define DASH_MAX_WS_CLIENTS DEFAULT_MAX_WS_CLIENTS
 #endif
 
 // Forward Declaration
@@ -117,6 +121,8 @@ class ESPDash{
     void sendUpdates(bool force = false);
 
     void refreshStatistics();
+
+    bool hasClient();
 
     ~ESPDash();
 };


### PR DESCRIPTION
This PR introduces `DASH_PARTIAL_UPDATE_JSON_SIZE` (defaulted to `DASH_LAYOUT_JSON_SIZE` for backward compatibility). This allows to reduce the reserved memory for most of the subsequent websocket push after the initial load of the page.

Also introduced `DASH_MAX_WS_CLIENTS` (defaulted to `DEFAULT_MAX_WS_CLIENTS`) to allow controlling the maximum number of WebSocket clients for DASH. The default is 8 for ESP32 (comes from the ESPAsyncWebServer lib).

The cleanup code has been added to make sure, before doing a WS push, that older clients gets closed in case the count is more than the allowed limit.

Also, a quick check has been added to avoid doing any memory intensive operation when the app triggers and dashboard.update() in case there is no client connected.

Also added `hasClient()` to allow callers to know if some WS clients are connected (i.e. to improve the update code to avoid running it)