### PR TITLE
6. Dependency fix

### DIFF
--- a/library.json
+++ b/library.json
@@ -21,12 +21,12 @@
   "dependencies":
   [
     {
-      "name": "ESP Async WebServer",
-      "version": "1.2.3"
+      "name": "ESPAsyncWebServer-esphome",
+      "version": "^3.1.0"
     },
     {
       "name": "ArduinoJson",
-      "version": "6.17.0"
+      "version": "^6.17.0"
     }
   ]
 }


### PR DESCRIPTION
- consider pointing to the ESPHome fork of ESPAsyncWebServer, which is in the hand of Nabu Casa the company behind Home Assistant also
- Consider opening the ArduinoJson version in order to avoid platformio downloading 2 different versions of the same library when we point to a more recent version