### PR TITLE
Allow to send web socket data in batches that are less than the defined memory capacity for the buffer

### DIFF
--- a/src/ESPDash.h
+++ b/src/ESPDash.h
@@ -45,20 +45,8 @@ Github URL: https://github.com/ayushsharma82/ESP-DASH
 #include "Chart.h"
 #include "Statistic.h"
 
-#ifndef DASH_LAYOUT_JSON_SIZE
-  #define DASH_LAYOUT_JSON_SIZE 1024 * 5
-#endif
-
-#ifndef DASH_PARTIAL_UPDATE_JSON_SIZE
-  #define DASH_PARTIAL_UPDATE_JSON_SIZE DASH_LAYOUT_JSON_SIZE
-#endif
-
-#ifndef DASH_CARD_JSON_SIZE
-  #define DASH_CARD_JSON_SIZE 256
-#endif
-
-#ifndef DASH_CHART_JSON_SIZE
-  #define DASH_CHART_JSON_SIZE 2048
+#ifndef DASH_JSON_SIZE
+  #define DASH_JSON_SIZE 2048
 #endif
 
 #ifndef DASH_USE_LEGACY_CHART_STORAGE
@@ -90,7 +78,8 @@ class ESPDash{
     uint32_t _idCounter = 0;
 
     // Generate layout json
-    size_t generateLayoutJSON(AsyncWebSocketClient *client, bool changes_only = false, Card *onlyCard = nullptr);
+    void generateLayoutJSON(AsyncWebSocketClient *client, bool changes_only = false, Card *onlyCard = nullptr);
+    void send(AsyncWebSocketClient *client, JsonDocument &json);
 
     // Generate Component JSON
     void generateComponentJSON(JsonObject& obj, Card* card, bool change_only = false);


### PR DESCRIPTION
This fix allows ESP-DASH to correctly observe the `DASH_PARTIAL_UPDATE_JSON_SIZE` and `DASH_LAYOUT_JSON_SIZE` memory limites: when the addition of a new card entry increases the payload too much, the current json is flushed to web socket and a new one is created.

This allows to send a batch of messages instead of a big first one, which can easily goes into out of memory in case of many many cards.

Define `DASH_DEBUG` to see the payloads sent.

![image](https://github.com/ayushsharma82/ESP-DASH/assets/61346/c2ba6ce0-2aca-4b65-8fa2-ce2a22c28455)

PR sent as draft because it requires a review / testing and generating oft he new UI.