### PR TITLE
Do not use String for names (which are usually constants)

### DIFF
--- a/src/Card.h
+++ b/src/Card.h
@@ -33,7 +33,7 @@ class Card {
     ESPDash *_dashboard;
 
     uint32_t _id;
-    String _name;
+    const char* _name;
     int   _type;
     bool  _changed;
     enum { INTEGER, FLOAT, STRING } _value_type;

--- a/src/Chart.h
+++ b/src/Chart.h
@@ -33,7 +33,7 @@ class Chart {
     ESPDash *_dashboard;
 
     uint32_t _id;
-    String _name;
+    const char *_name;
     int   _type;
     bool  _changed;
     GraphAxisType _x_axis_type;

--- a/src/ESPDash.cpp
+++ b/src/ESPDash.cpp
@@ -353,7 +353,7 @@ size_t ESPDash::generateLayoutJSON(AsyncWebSocketClient *client, bool changes_on
 void ESPDash::generateComponentJSON(JsonObject& doc, Card* card, bool change_only){
   doc["id"] = card->_id;
   if(!change_only){
-    doc["n"] = card->_name.c_str();
+    doc["n"] = card->_name;
     doc["t"] = cardTags[card->_type].type;
     doc["min"] = card->_value_min;
     doc["max"] = card->_value_max;
@@ -386,7 +386,7 @@ void ESPDash::generateComponentJSON(JsonObject& doc, Card* card, bool change_onl
 void ESPDash::generateComponentJSON(JsonObject& doc, Chart* chart, bool change_only){
   doc["id"] = chart->_id;
   if(!change_only){
-    doc["n"] = chart->_name.c_str();
+    doc["n"] = chart->_name;
     doc["t"] = chartTags[chart->_type].type;
   }
 

--- a/src/Statistic.cpp
+++ b/src/Statistic.cpp
@@ -4,18 +4,9 @@ Statistic::Statistic(ESPDash *dashboard, const char *key, const char *value) {
     _dashboard = dashboard;
     _id = dashboard->nextId();
     // Safe copy
-    strncpy(_key, key, sizeof(_key));
+    _key = key;
     strncpy(_value, value, sizeof(_value));
     _dashboard->add(this);
-}
-
-void Statistic::set(const char *key, const char *value) {
-    // Safe copy
-    _changed = strcmp(_value, value) != 0 || strcmp(_key, key) != 0;
-    if(_changed) {
-        strncpy(_key, key, sizeof(_key));
-        strncpy(_value, value, sizeof(_value));
-    }
 }
 
 void Statistic::set(const char *value) {

--- a/src/Statistic.h
+++ b/src/Statistic.h
@@ -15,13 +15,12 @@ class Statistic {
     private:
         ESPDash *_dashboard;
         uint32_t _id;
-        char _key[32];
+        const char *_key;
         char _value[64];
         bool _changed = false;
 
     public:
         Statistic(ESPDash *dashboard, const char *key, const char *value = "");
-        void set(const char *key, const char *value);
         void set(const char *value);
         ~Statistic();
 


### PR DESCRIPTION
This PR switches back to `const char*` instead of using `String` for constant names.

Also, no need to be able to update keys in stats: they can just be removed or added.

Making names and keys constant allows a huge reduction of memory usage when we have a lot of stats and cards.