### PR TITLE
Arduino 3 / ESP-IDF 5 compatibility

### DIFF
--- a/.github/scripts/dep-install.sh
+++ b/.github/scripts/dep-install.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-cd ${HOME}/Arduino/libraries
-git clone https://github.com/me-no-dev/ESPAsyncWebServer.git ESPAsyncWebServer
-git clone https://github.com/me-no-dev/ESPAsyncTCP.git ESPAsyncTCP
-git clone https://github.com/me-no-dev/AsyncTCP.git AsyncTCP
-git clone --single-branch --branch 7.x https://github.com/bblanchon/ArduinoJson.git ArduinoJson

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,44 +1,118 @@
 name: Arduino Library CI
 
-on: 
+on:
   push:
     paths-ignore:
-      - '**/**.md'
-      - '/keywords.txt'
-      - '/library.json'
-      - '/library.properties'
-      - '/vue-frontend'
-      - '/docs'
+      - "**/**.md"
+      - "/keywords.txt"
+      - "/library.json"
+      - "/library.properties"
+      - "/vue-frontend"
+      - "/docs"
   pull_request:
     paths-ignore:
-      - '**/**.md'
-      - '/keywords.txt'
-      - '/library.json'
-      - '/library.properties'
-      - '/vue-frontend'
-      - '/docs'
+      - "**/**.md"
+      - "/keywords.txt"
+      - "/library.json"
+      - "/library.properties"
+      - "/vue-frontend"
+      - "/docs"
 
 jobs:
-  build:
+  arduino:
+    name: arduino ${{ matrix.platform }}
     runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [esp8266, esp32]
+
     steps:
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.x'
-      
+          python-version: "3.x"
+
       - uses: actions/checkout@v2
 
       - uses: actions/checkout@v2
         with:
-           repository: ayushsharma82/ci-arduino
-           path: ci
+          repository: ayushsharma82/ci-arduino
+          path: ci
 
       - name: pre-install
         run: bash ci/actions_install.sh
-        
-      - name: install-deps
-        run: bash .github/scripts/dep-install.sh
 
-      - name: test platforms
-        run: python3 ci/build_platform.py esp8266 esp32
+      - name: Set configuration
+        run: arduino-cli config set library.enable_unsafe_install true
+
+      - name: Install AsyncTCP
+        run: arduino-cli lib install --git-url https://github.com/mathieucarbou/AsyncTCP#v3.1.2
+
+      - name: Install ESPAsyncWebServer
+        run: arduino-cli lib install --git-url https://github.com/mathieucarbou/ESPAsyncWebServer#v2.10.0
+
+      - name: Install ESPAsyncTCP
+        run: arduino-cli lib install --git-url https://github.com/mathieucarbou/esphome-ESPAsyncTCP#v2.0.0
+
+      - name: Install ArduinoJson
+        run: arduino-cli lib install --git-url https://github.com/bblanchon/ArduinoJson#v7.0.4
+
+      - name: Build Examples
+        run: python3 ci/build_platform.py ${{ matrix.platform }}
+
+  platformio:
+    name: pio ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: esp32dev|arduino
+            board: esp32dev
+            platform: espressif32
+            opts:
+          - name: esp32dev|arduino-2
+            board: esp32dev
+            platform: espressif32@6.7.0
+            opts:
+          - name: esp32dev|arduino-3
+            board: esp32dev
+            platform: espressif32
+            opts: "--project-option 'platform_packages=platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0, platform_packages=platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.0/esp32-arduino-libs-3.0.0.zip'"
+          - name: esp32-s3-devkitc-1|arduino
+            board: esp32-s3-devkitc-1
+            platform: espressif32
+            opts:
+          - name: esp32-s3-devkitc-1|arduino-2
+            board: esp32-s3-devkitc-1
+            platform: espressif32@6.7.0
+            opts:
+          - name: esp32-s3-devkitc-1|arduino-3
+            board: esp32-s3-devkitc-1
+            platform: espressif32
+            opts: "--project-option 'platform_packages=platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0, platform_packages=platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.0/esp32-arduino-libs-3.0.0.zip'"
+          - name: huzzah|espressif8266
+            board: huzzah
+            platform: espressif8266
+            opts:
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: ${{ matrix.name }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install platformio
+      - run: platformio platform install ${{ matrix.platform }}
+
+      - run: platformio ci "examples/AccessPoint/AccessPoint.ino" -l '.' -b ${{ matrix.board }} ${{ matrix.opts }}
+      - run: platformio ci "examples/Basic/Basic.ino" -l '.' -b ${{ matrix.board }} ${{ matrix.opts }}
+      - run: platformio ci "examples/Benchmark/Benchmark.ino" -l '.' -b ${{ matrix.board }} ${{ matrix.opts }}
+      - run: platformio ci "examples/Chart/Chart.ino" -l '.' -b ${{ matrix.board }} ${{ matrix.opts }}
+      - run: platformio ci "examples/Dynamic/Dynamic.ino" -l '.' -b ${{ matrix.board }} ${{ matrix.opts }}
+      - run: platformio ci "examples/Interactive/Interactive.ino" -l '.' -b ${{ matrix.board }} ${{ matrix.opts }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ node_modules
 ./vue-frontend/dist
 /build
 /portal
+
+/.pio
+/logs

--- a/library.json
+++ b/library.json
@@ -18,13 +18,18 @@
   "version": "4.0.4",
   "frameworks": "arduino",
   "platforms": ["espressif32", "espressif8266"],
-  "dependencies":
-  [
+  "dependencies": [
     {
-      "name": "ESP Async WebServer"
+      "owner": "bblanchon",
+      "name": "ArduinoJson",
+      "version": "^7.0.4",
+      "platforms": ["espressif8266", "espressif32"]
     },
     {
-      "name": "ArduinoJson"
+      "owner": "mathieucarbou",
+      "name": "ESP Async WebServer",
+      "version": "^2.10.0",
+      "platforms": ["espressif8266", "espressif32"]
     }
   ]
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,45 @@
+[env]
+framework = arduino
+build_flags = 
+  -Wall -Wextra
+  -D CONFIG_ARDUHAL_LOG_COLORS
+  -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+lib_deps = 
+  bblanchon/ArduinoJson @ 7.0.4
+  mathieucarbou/Async TCP @ ^3.1.2
+  mathieucarbou/ESP Async WebServer @ 2.10.0
+upload_protocol = esptool
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder, log2file
+
+[platformio]
+lib_dir = .
+; src_dir = examples/AccessPoint
+; src_dir = examples/Basic
+src_dir = examples/Benchmark
+; src_dir = examples/Chart
+; src_dir = examples/Dynamic
+; src_dir = examples/Interactive
+
+[env:arduino]
+platform = espressif32
+board = esp32-s3-devkitc-1
+
+[env:arduino-2]
+platform = espressif32@6.7.0
+board = esp32-s3-devkitc-1
+
+[env:arduino-3]
+platform = espressif32
+platform_packages=
+  platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0
+  platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.0/esp32-arduino-libs-3.0.0.zip
+board = esp32-s3-devkitc-1
+
+[env:esp8266]
+platform = espressif8266
+board = huzzah
+lib_deps = 
+  bblanchon/ArduinoJson @ 7.0.4
+  mathieucarbou/ESP Async WebServer @ 2.10.0
+  esphome/ESPAsyncTCP-esphome @ 2.0.0


### PR DESCRIPTION
This PR updates some project files (CI and library.json) to ensure compatibility with Arduino 3 / ESP-IDF 5.

The project itself does not require any change (**I tested the benchmark example on ESP32S3 with Arduino 3 RC1**), except the library.json for PlatformIO projects, but these dependencies must be used, which have been updated to support Arduino 3 / ESP-IDF 5:

- https://github.com/mathieucarbou/AsyncTCP
- https://github.com/mathieucarbou/ESPAsyncWebServer

Example:

```
lib_deps = 
  mathieucarbou/Async TCP @ ^3.0.2
  mathieucarbou/ESP Async WebServer @ 2.9.3
```

You can see the PR build in my fork with the new CI files: https://github.com/mathieucarbou/ayushsharma82-ESP-DASH/actions/runs/8774146477