### PR TITLE
Before update callback

### DIFF
--- a/src/ESPDash.cpp
+++ b/src/ESPDash.cpp
@@ -64,6 +64,8 @@ ESPDash::ESPDash(AsyncWebServer* server, const char* uri, bool enable_default_st
           // client side commands parsing
           if (json["command"] == "get:layout") {
             _asyncAccessInProgress = true;
+            if (_beforeUpdateCallback)
+              _beforeUpdateCallback(false);
             generateLayoutJSON(client, false);
             _asyncAccessInProgress = false;
           } else if (json["command"] == "ping") {
@@ -487,6 +489,8 @@ void ESPDash::sendUpdates(bool force) {
   if (!hasClient()) {
     return;
   }
+  if (_beforeUpdateCallback)
+    _beforeUpdateCallback(!force);
   generateLayoutJSON(nullptr, !force);
 }
 
@@ -495,6 +499,8 @@ void ESPDash::refreshCard(Card *card) {
   if (!hasClient()) {
     return;
   }
+  if (_beforeUpdateCallback)
+    _beforeUpdateCallback(true);
   generateLayoutJSON(nullptr, true, card);
 }
 

--- a/src/ESPDash.h
+++ b/src/ESPDash.h
@@ -68,6 +68,11 @@ class Statistic;
 
 // ESPDASH Class
 class ESPDash{
+  public:
+    // changes_only: true (equivalent to sendUpdates(false)) - when sending updates to the client
+    // changes_only: false (equivalent to sendUpdates(true)) - when sending the entire layout to the client or when forcing a full update
+    typedef std::function<void(bool changes_only)> BeforeUpdateCallback;
+
   private:
     AsyncWebServer* _server = nullptr;
     AsyncWebSocket* _ws = nullptr;
@@ -80,6 +85,7 @@ class ESPDash{
     char username[64];
     char password[64];
     uint32_t _idCounter = 0;
+    BeforeUpdateCallback _beforeUpdateCallback = nullptr;
 
     volatile bool _asyncAccessInProgress = false;
 
@@ -128,6 +134,12 @@ class ESPDash{
     // can be used to check if the async_http task might currently access the cards data, 
     // in which case you should not modify them
     bool isAsyncAccessInProgress() { return _asyncAccessInProgress; }
+
+    // Register a callback that will be called before some updates will be sent to the client.
+    // This callback can be used for example to refresh some card values that never change after only when a full layout is request (i.e. on page reload).
+    // This allows to avoid spending time refreshing cards that never change, but still allows them to be refreshed hen the user refresh the dashboard.
+    // If called from the async_http task, isAsyncAccessInProgress() will return true while in this callback.
+    void onBeforeUpdate(BeforeUpdateCallback callback) { _beforeUpdateCallback = callback; }
 
     ~ESPDash();
 };


### PR DESCRIPTION
Introducing a callback to let the application aware when a refresh is requested, and if it is partial or not.

This helps improving performance by only refreshing some cards when the user reloads a page and not in a regular loop.

Example:

```
  dashboard.onBeforeUpdate([](bool changes_only) {
    if (!changes_only) {
      logger.debug(TAG, "Dashboard refresh requested");
      YaSolR::Website.initCards();
    }
  });
```

Then, we don't need to "prepare" any card before, but only when requested.

I.e. `initCards()` contain some `card.update()` calls for some application config, app info, etc. Basically values that are either never refreshed (app scope), or infrequently refreshed (i.e. a config could be updated through mqtt behind), so only refreshing them when the user refreshed the web page is acceptable.