### PR TITLE
Several improvements regarding transfer size and speed

### DIFF
--- a/src/Chart.cpp
+++ b/src/Chart.cpp
@@ -58,7 +58,7 @@ void Chart::updateX(int arr_x[], size_t x_size){
     _x_axis_i_ptr = arr_x;
     _x_axis_ptr_size = x_size;
   #endif
-  _changed = true;
+  _x_changed = true;
 }
 
 void Chart::updateX(float arr_x[], size_t x_size){
@@ -73,7 +73,7 @@ void Chart::updateX(float arr_x[], size_t x_size){
     _x_axis_f_ptr = arr_x;
     _x_axis_ptr_size = x_size;
   #endif
-  _changed = true;
+  _x_changed = true;
 }
 
 void Chart::updateX(String arr_x[], size_t x_size){
@@ -88,7 +88,7 @@ void Chart::updateX(String arr_x[], size_t x_size){
     _x_axis_s_ptr = arr_x;
     _x_axis_ptr_size = x_size;
   #endif
-  _changed = true;
+  _x_changed = true;
 }
 
 void Chart::updateX(const char* arr_x[], size_t x_size){
@@ -103,7 +103,7 @@ void Chart::updateX(const char* arr_x[], size_t x_size){
     _x_axis_char_ptr = arr_x;
     _x_axis_ptr_size = x_size;
   #endif
-  _changed = true;
+  _x_changed = true;
 }
 
 void Chart::updateY(int arr_y[], size_t y_size){
@@ -118,7 +118,7 @@ void Chart::updateY(int arr_y[], size_t y_size){
     _y_axis_i_ptr = arr_y;
     _y_axis_ptr_size = y_size;
   #endif
-  _changed = true;
+  _y_changed = true;
 }
 
 void Chart::updateY(float arr_y[], size_t y_size){
@@ -133,7 +133,7 @@ void Chart::updateY(float arr_y[], size_t y_size){
     _y_axis_f_ptr = arr_y;
     _y_axis_ptr_size = y_size;
   #endif
-  _changed = true;
+  _y_changed = true;
 }
 
 /*

--- a/src/Chart.h
+++ b/src/Chart.h
@@ -35,7 +35,8 @@ class Chart {
     uint32_t _id;
     const char *_name;
     int   _type;
-    bool  _changed;
+    bool  _x_changed;
+    bool  _y_changed;
     GraphAxisType _x_axis_type;
     GraphAxisType _y_axis_type;
 

--- a/src/ESPDash.cpp
+++ b/src/ESPDash.cpp
@@ -226,7 +226,7 @@ void ESPDash::generateLayoutJSON(AsyncWebSocketClient* client, bool changes_only
   for (int i = 0; i < charts.Size(); i++) {
     Chart* c = charts[i];
     if (changes_only) {
-      if (!c->_changed) {
+      if (!c->_x_changed && !c->_y_changed) {
         continue;
       }
     }
@@ -249,7 +249,8 @@ void ESPDash::generateLayoutJSON(AsyncWebSocketClient* client, bool changes_only
 
     // Clear change flags
     if (changes_only) {
-      c->_changed = false;
+      c->_x_changed = false;
+      c->_y_changed = false;
     }
   }
 
@@ -402,84 +403,88 @@ void ESPDash::generateComponentJSON(JsonObject& doc, Chart* chart, bool change_o
     doc["t"] = chartTags[chart->_type].type;
   }
 
-  JsonArray xAxis = doc["x"].to<JsonArray>();
-  switch (chart->_x_axis_type) {
-    case GraphAxisType::INTEGER:
-      #if DASH_USE_LEGACY_CHART_STORAGE == 1
-        for(int i=0; i < chart->_x_axis_i.Size(); i++)
-          xAxis.add(chart->_x_axis_i[i]);
-      #else
-        if (chart->_x_axis_i_ptr != nullptr) {
-          for(unsigned int i=0; i < chart->_x_axis_ptr_size; i++)
-            xAxis.add(chart->_x_axis_i_ptr[i]);
-        }
-      #endif
-      break;
-    case GraphAxisType::FLOAT:
-      #if DASH_USE_LEGACY_CHART_STORAGE == 1
-        for(int i=0; i < chart->_x_axis_f.Size(); i++)
-          xAxis.add(chart->_x_axis_f[i]);
-      #else
-        if (chart->_x_axis_f_ptr != nullptr) {
-          for(unsigned int i=0; i < chart->_x_axis_ptr_size; i++)
-            xAxis.add(chart->_x_axis_f_ptr[i]);
-        }
-      #endif
-      break;
-    case GraphAxisType::CHAR:
-      #if DASH_USE_LEGACY_CHART_STORAGE == 1
-        for(int i=0; i < chart->_x_axis_s.Size(); i++)
-          xAxis.add(chart->_x_axis_s[i].c_str());
-      #else
-        if (chart->_x_axis_char_ptr != nullptr) {
-          for(unsigned int i=0; i < chart->_x_axis_ptr_size; i++)
-            xAxis.add(chart->_x_axis_char_ptr[i]);
-        }
-      #endif
-      break;
-    case GraphAxisType::STRING:
-      #if DASH_USE_LEGACY_CHART_STORAGE == 1
-        for(int i=0; i < chart->_x_axis_s.Size(); i++)
-          xAxis.add(chart->_x_axis_s[i].c_str());
-      #else
-        if (chart->_x_axis_s_ptr != nullptr) {
-          for(unsigned int i=0; i < chart->_x_axis_ptr_size; i++)
-            xAxis.add(chart->_x_axis_s_ptr[i]);
-        }
-      #endif
-      break;
-    default:
-      // blank value
-      break;
+  if(!change_only || chart->_x_changed) {
+    JsonArray xAxis = doc["x"].to<JsonArray>();
+    switch (chart->_x_axis_type) {
+      case GraphAxisType::INTEGER:
+        #if DASH_USE_LEGACY_CHART_STORAGE == 1
+          for(int i=0; i < chart->_x_axis_i.Size(); i++)
+            xAxis.add(chart->_x_axis_i[i]);
+        #else
+          if (chart->_x_axis_i_ptr != nullptr) {
+            for(unsigned int i=0; i < chart->_x_axis_ptr_size; i++)
+              xAxis.add(chart->_x_axis_i_ptr[i]);
+          }
+        #endif
+        break;
+      case GraphAxisType::FLOAT:
+        #if DASH_USE_LEGACY_CHART_STORAGE == 1
+          for(int i=0; i < chart->_x_axis_f.Size(); i++)
+            xAxis.add(chart->_x_axis_f[i]);
+        #else
+          if (chart->_x_axis_f_ptr != nullptr) {
+            for(unsigned int i=0; i < chart->_x_axis_ptr_size; i++)
+              xAxis.add(chart->_x_axis_f_ptr[i]);
+          }
+        #endif
+        break;
+      case GraphAxisType::CHAR:
+        #if DASH_USE_LEGACY_CHART_STORAGE == 1
+          for(int i=0; i < chart->_x_axis_s.Size(); i++)
+            xAxis.add(chart->_x_axis_s[i].c_str());
+        #else
+          if (chart->_x_axis_char_ptr != nullptr) {
+            for(unsigned int i=0; i < chart->_x_axis_ptr_size; i++)
+              xAxis.add(chart->_x_axis_char_ptr[i]);
+          }
+        #endif
+        break;
+      case GraphAxisType::STRING:
+        #if DASH_USE_LEGACY_CHART_STORAGE == 1
+          for(int i=0; i < chart->_x_axis_s.Size(); i++)
+            xAxis.add(chart->_x_axis_s[i].c_str());
+        #else
+          if (chart->_x_axis_s_ptr != nullptr) {
+            for(unsigned int i=0; i < chart->_x_axis_ptr_size; i++)
+              xAxis.add(chart->_x_axis_s_ptr[i]);
+          }
+        #endif
+        break;
+      default:
+        // blank value
+        break;
+    }
   }
 
-  JsonArray yAxis = doc["y"].to<JsonArray>();
-  switch (chart->_y_axis_type) {
-    case GraphAxisType::INTEGER:
-      #if DASH_USE_LEGACY_CHART_STORAGE == 1
-        for(int i=0; i < chart->_y_axis_i.Size(); i++)
-          yAxis.add(chart->_y_axis_i[i]);
-      #else
-        if (chart->_y_axis_i_ptr != nullptr) {
-          for(unsigned int i=0; i < chart->_y_axis_ptr_size; i++)
-            yAxis.add(chart->_y_axis_i_ptr[i]);
-        }
-      #endif
-      break;
-    case GraphAxisType::FLOAT:
-      #if DASH_USE_LEGACY_CHART_STORAGE == 1
-        for(int i=0; i < chart->_y_axis_f.Size(); i++)
-          yAxis.add(chart->_y_axis_f[i]);
-      #else
-        if (chart->_y_axis_f_ptr != nullptr) {
-          for(unsigned int i=0; i < chart->_y_axis_ptr_size; i++)
-            yAxis.add(chart->_y_axis_f_ptr[i]);
-        }
-      #endif
-      break;
-    default:
-      // blank value
-      break;
+  if(!change_only || chart->_y_changed) {
+    JsonArray yAxis = doc["y"].to<JsonArray>();
+    switch (chart->_y_axis_type) {
+      case GraphAxisType::INTEGER:
+        #if DASH_USE_LEGACY_CHART_STORAGE == 1
+          for(int i=0; i < chart->_y_axis_i.Size(); i++)
+            yAxis.add(chart->_y_axis_i[i]);
+        #else
+          if (chart->_y_axis_i_ptr != nullptr) {
+            for(unsigned int i=0; i < chart->_y_axis_ptr_size; i++)
+              yAxis.add(chart->_y_axis_i_ptr[i]);
+          }
+        #endif
+        break;
+      case GraphAxisType::FLOAT:
+        #if DASH_USE_LEGACY_CHART_STORAGE == 1
+          for(int i=0; i < chart->_y_axis_f.Size(); i++)
+            yAxis.add(chart->_y_axis_f[i]);
+        #else
+          if (chart->_y_axis_f_ptr != nullptr) {
+            for(unsigned int i=0; i < chart->_y_axis_ptr_size; i++)
+              yAxis.add(chart->_y_axis_f_ptr[i]);
+          }
+        #endif
+        break;
+      default:
+        // blank value
+        break;
+    }
   }
 }
 


### PR DESCRIPTION
Here is an optimisation for the charts I also did in my dev branch for the pro version.

I have an app with 3 charts of 120 points each, which means 120×2×3 = 720 points are transferred each 500ms. That's a lot. And the scale does not change because its a real-time graph:

![image](https://github.com/ayushsharma82/ESP-DASH/assets/61346/36b935ed-e65b-4ab7-83d3-9b5b40a5624c)

So I've split the change detection between x and y axis to only send the data for the axis which really changed.

Saves half the data.