### PR TITLE
Float support on slider

### DIFF
--- a/src/Card.cpp
+++ b/src/Card.cpp
@@ -15,6 +15,21 @@ Card::Card(ESPDash *dashboard, const int type, const char* name, const char* sym
   _dashboard->add(this);
 }
 
+Card::Card(ESPDash *dashboard, const int type, const char* name, const char* symbol, const float min, const float max, const float step){
+  _dashboard = dashboard;
+  _id = dashboard->nextId();
+  _type = type;
+  _name = name;
+  _symbol = symbol;
+  _value_min_f = min;
+  _value_max_f = max;
+  _value_step_f = step;
+
+  _value_type = Card::FLOAT;
+
+  _dashboard->add(this);
+}
+
 /*
   Attach Function Callback
 */
@@ -22,6 +37,12 @@ void Card::attachCallback(std::function<void(int value)> cb){
   _callback = cb;
 }
 
+/*
+  Attach Function Callback
+*/
+void Card::attachCallbackF(std::function<void(float value)> cb){
+  _callback_f = cb;
+}
 
 /*
   Value update methods

--- a/src/Card.h
+++ b/src/Card.h
@@ -42,15 +42,27 @@ class Card {
         int _value_i;
     };
     String _value_s;
-    int _value_min;
-    int _value_max;
-    int _value_step;
+    union alignas(4) {
+        float _value_min_f;
+        int _value_min;
+    };
+    union alignas(4) {
+        float _value_max_f;
+        int _value_max;
+    };
+    union alignas(4) {
+        float _value_step_f;
+        int _value_step;
+    };
     String _symbol;
     std::function<void(int value)> _callback = nullptr;
+    std::function<void(float value)> _callback_f = nullptr;
 
   public:
     Card(ESPDash *dashboard, const int type, const char* name, const char* symbol = "", const int min = 0, const int max = 0, const int step = 1);
+    Card(ESPDash *dashboard, const int type, const char* name, const char* symbol, const float min, const float max, const float step);
     void attachCallback(std::function<void(int)> cb);
+    void attachCallbackF(std::function<void(float)> cb);
     void update(int value);
     void update(int value, const char* symbol);
     void update(bool value);

--- a/src/ESPDash.cpp
+++ b/src/ESPDash.cpp
@@ -89,7 +89,11 @@ ESPDash::ESPDash(AsyncWebServer* server, const char* uri, bool enable_default_st
             for(int i=0; i < cards.Size(); i++){
               Card *p = cards[i];
               if(id == p->_id){
-                if(p->_callback != nullptr){
+                if(p->_callback_f != nullptr && p->_value_type == Card::FLOAT){
+                  _asyncAccessInProgress = true;
+                  p->_callback_f(json["value"].as<float>());
+                  _asyncAccessInProgress = false;
+                } else if(p->_callback != nullptr) {
                   _asyncAccessInProgress = true;
                   p->_callback(json["value"].as<int>());
                   _asyncAccessInProgress = false;
@@ -373,10 +377,17 @@ void ESPDash::generateComponentJSON(JsonObject& doc, Card* card, bool change_onl
   if (!change_only){
     doc["n"] = card->_name;
     doc["t"] = cardTags[card->_type].type;
-    doc["min"] = card->_value_min;
-    doc["max"] = card->_value_max;
-    if (card->_value_step != 1)
-      doc["step"] = card->_value_step;
+    if (card->_type == SLIDER_CARD || card->_type == PROGRESS_CARD) {
+      if(card->_value_type == Card::FLOAT) {
+        doc["min"] = String(card->_value_min_f, 2);
+        doc["max"] = String(card->_value_max_f, 2);
+        doc["step"] = String(card->_value_step_f, 2);
+      } else {
+        doc["min"] = card->_value_min;
+        doc["max"] = card->_value_max;
+        doc["step"] = card->_value_step;
+      }
+    }
   }
   if(change_only || !card->_symbol.isEmpty())
     doc["s"] = card->_symbol;


### PR DESCRIPTION
This change allows to create slider and progress cards with float values, useful when using percentages where a decimal resolution is required.

Also available for pro users in my repo if you want to take it.

There is also a new RangeSlider that I added: 
![image](https://github.com/user-attachments/assets/3ebeaa33-da46-42a7-91a0-fa29c9297a33)